### PR TITLE
Preview first subset of font

### DIFF
--- a/src/js/components/MainView/FontPreview.js
+++ b/src/js/components/MainView/FontPreview.js
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Slider, Tooltip } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
+import previewGenerator from '../previewGenerator';
+
 import { H2 } from '../general/Headers';
 import P from '../general/Paragraph';
 
@@ -74,7 +76,7 @@ export default function FontPreview({ fontData, fontLoaded }) {
               fontSize: `${fontSize}px`,
             }}
           >
-            The quick brown fox jumps over the lazy dog.
+            {previewGenerator(fontData.defSubset, fontData.fontId)}
           </span>
         </P>
       ) : (

--- a/src/js/components/MainView/index.js
+++ b/src/js/components/MainView/index.js
@@ -32,11 +32,11 @@ export default function FontViewer({ view }) {
         .then(response => response.json())
         .then(data => {
           setFontData(data);
-
+          console.log(fontSourceData.pkg(data.fontId, data.defSubset).preview);
           // Fetch font file
           new FontFace(
             data.fontId,
-            `url(${fontSourceData.pkg(data.fontId, data.subsets[0]).preview})`
+            `url(${fontSourceData.pkg(data.fontId, data.defSubset).preview})`
           )
             .load()
             .then(result => {

--- a/src/js/components/MainView/index.js
+++ b/src/js/components/MainView/index.js
@@ -33,18 +33,16 @@ export default function FontViewer({ view }) {
         .then(data => {
           setFontData(data);
 
-          if (data.subsets.includes('latin')) {
-            // Fetch font file
-            new FontFace(
-              data.fontId,
-              `url(${fontSourceData.pkg(data.fontId, 'latin').preview})`
-            )
-              .load()
-              .then(result => {
-                document.fonts.add(result);
-                setFontLoaded(true);
-              });
-          }
+          // Fetch font file
+          new FontFace(
+            data.fontId,
+            `url(${fontSourceData.pkg(data.fontId, data.subsets[0]).preview})`
+          )
+            .load()
+            .then(result => {
+              document.fonts.add(result);
+              setFontLoaded(true);
+            });
         });
 
       // Fetch font file

--- a/src/js/components/previewGenerator.js
+++ b/src/js/components/previewGenerator.js
@@ -1,0 +1,51 @@
+export default function previewGenerator(subset, id) {
+  switch (id) {
+    case 'dseg-weather':
+    case 'dseg14':
+    case 'dseg7':
+      return '0123456789';
+
+    case 'material-icons':
+      return 'photo_camera thumb_up assignment create_new_folder insert_invitation drafts credit_card timer check_box close';
+
+    case 'yakuhanjp':
+    case 'yakuhanrp':
+      return '、。！？〈〉《》「」『』【】〔〕・（）：；［］｛｝';
+
+    case 'yakuhanjps':
+    case 'yakuhanrps':
+      return '〈〉《》「」『』【】〔〕（）［］｛｝';
+
+    case 'yakuhanmp':
+      return '、。！？《》「」『』【】〔〕・（）：；［］｛｝';
+    case 'yakuhanmps':
+      return '《》「」『』【】〔〕（）［］｛｝';
+
+    default:
+      break;
+  }
+
+  switch (subset) {
+    case 'latin':
+    case 'latin-ext':
+    case 'all':
+      return 'The quick brown fox jumps over the lazy dog.';
+
+    case 'arabic':
+      return '.الحب سماء لا تمطر غير الأحلام';
+
+    case 'greek':
+      return 'Ήταν απλώς θέμα χρόνου.';
+
+    case 'khmer':
+      return 'ខ្ញុំបានមើលព្យុះ ដែលមានភាពស្រស់ស្អាតណាស់ ប៉ុន្តែគួរឲ្យខ្លាច';
+
+    case 'korean':
+      return '그들의 장비와 기구는 모두 살아 있다.';
+
+    default:
+      return '';
+  }
+}
+
+// case '':

--- a/src/js/fontSourceData.js
+++ b/src/js/fontSourceData.js
@@ -7,7 +7,7 @@ const fontSourceData = {
 
   /**
    * @param {string} pkg
-   * @param {string} [subset]
+   * @param {string} subset
    */
   pkg(pkg, subset) {
     const folder = `${baseUrl}/packages/${pkg}`;


### PR DESCRIPTION
Currently, the only font subset that can appear in a preview on the site is `latin`:

https://github.com/fontsource/search-directory/blob/84b75e8682fa43fedacd12e2302fac7a3b7bc14c/src/js/components/MainView/index.js#L36-L41

This works fine for most fonts, but not all. Cascadia Code, for example, has subsets `latin-ext` and `pl-latin-ext`. It doesn't have the `latin` subset, so there's no preview. No preview makes this tool pretty pointless.

This PR changes that to preview the first subset provided by the font (`data.subsets[0]`). Now there's always a preview.

It seems like `latin` is always listed first for each font, so if `latin` is available, that's the preview. If that's not always the case, frankly, I don't care - _any_ preview is better than none.